### PR TITLE
fix: add ControllerProxy to public API declaration

### DIFF
--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -4,3 +4,4 @@
 
 export * from './lib/rico-angular.service';
 export * from './lib/rico-angular.module';
+export * from './lib/controller-proxy';


### PR DESCRIPTION
add missiing delclaration to allow imports like 

`import { RicoService, ControllerProxy } from 'rico-angular';`
